### PR TITLE
kubernetes 1.18 より必要となったパッケージ conntrack の追加インストール

### DIFF
--- a/minikube.yml
+++ b/minikube.yml
@@ -16,7 +16,7 @@
 
   - name: Install packages
     apt:
-      name: ['apt-transport-https', 'ca-certificates', 'curl', 'software-properties-common', 'nfs-common']
+      name: ['apt-transport-https', 'ca-certificates', 'curl', 'software-properties-common', 'nfs-common', 'conntrack']
       state: present
       update_cache: yes
 


### PR DESCRIPTION
noneドライバで実行しようとした場合
> X Sorry, Kubernetes v1.18.0 requires conntrack to be installed in root's path

というエラーで失敗する、 kubernetes/minikube#7179 の事象に対応します。

その他リンク:

- [vagrantのLinuxでminikubeを動かしたい - スタック・オーバーフロー](https://ja.stackoverflow.com/q/66063/2808)